### PR TITLE
allow minor versions, remove uncessary dep

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,8 @@
   ],
   "require": {
     "php": ">=7.1",
-    "fond-of-spryker/shipment-table-rate-data-import": "~2.0.1",
-    "spryker/kernel": "~3.27.0",
-    "spryker/shipment": "~6.6.0"
+    "spryker/kernel": "^3.27.0",
+    "spryker/shipment": "^6.6.0"
   },
   "require-dev": {
     "spryker/code-sniffer": "^0.11",


### PR DESCRIPTION
In order to update Spryker Core features we need to allow minor versions in custom packages.

Additionally we remove the dependency of shipment-table-rate-date-import because there should only be a unidirectional dependency. 